### PR TITLE
Fixed paths for another OS where pref and accounts are on different directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 build/
 dist/
 *egg-info
+
+# IDE
+.history

--- a/README.md
+++ b/README.md
@@ -7,6 +7,16 @@ Utility used to decrypt remmina password accounts
 
 ..runs the game :)
 
-If you have .remmina folder backed up somewhere
+If you have .remmina folder backed up somewhere on in another directory:
 
-`REMMINA_FOLDER=/home/old-home/.remmina/ remmina_password_exposer.py`
+`REMMINA_FOLDER=~/.local/share/remmina/ ./remmina_password_exposer.py`
+
+`REMMINA_FOLDER` is the `env` variable to define where is the the accounts files (ex: `group_rdp_windows_server.remmina`) and `remmina.pref` file.
+
+If you have the `remmina.pref` in another directory, you can overwrite using `REMMINA_PREF`:
+
+`REMMINA_PREF=~/.config/remmina/remmina.pref ./remmina_password_exposer.py`
+
+Debug mode:
+
+`DEBUG=1 ./remmina_password_exposer.py`

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Utility used to decrypt remmina password accounts
 
 ..runs the game :)
 
-If you have .remmina folder backed up somewhere or in another directory:
+If you have .remmina folder backed up somewhere or another directory:
 
 `REMMINA_FOLDER=~/.local/share/remmina/ ./remmina_password_exposer.py`
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Utility used to decrypt remmina password accounts
 
 ..runs the game :)
 
-If you have .remmina folder backed up somewhere on in another directory:
+If you have .remmina folder backed up somewhere or in another directory:
 
 `REMMINA_FOLDER=~/.local/share/remmina/ ./remmina_password_exposer.py`
 

--- a/remmina_password_exposer/remmina_password_exposer.py
+++ b/remmina_password_exposer/remmina_password_exposer.py
@@ -15,15 +15,19 @@ except Exception as e:
 # ENV
 HOME = os.path.expanduser("~")
 CHARSET = 'utf-8'
+
 REMMINA_FOLDER = os.getenv('REMMINA_FOLDER', HOME+'/'+'.remmina/')
-REMMINA_PREF   = 'remmina.pref'
-REGEXP_ACCOUNTS = r'[0-9]{13}\.remmina(.swp)?'
-REGEXP_PREF     = r'remmina.pref'
+if REMMINA_FOLDER[-1] != '/':
+    REMMINA_FOLDER = REMMINA_FOLDER+'/'
+
+REMMINA_PREF   = os.getenv('REMMINA_PREF', REMMINA_FOLDER+'remmina.pref')
+REGEXP_ACCOUNTS = r'([^.]+)\.remmina(.swp)?'
+DEBUG = os.getenv('DEBUG', '')
 
 def show_remmina_accounts(debug=False):
     diz = {}
     res = []
-    fs = open(REMMINA_FOLDER+REMMINA_PREF)
+    fs = open(REMMINA_PREF)
     fso = fs.readlines()
     fs.close()
     
@@ -59,4 +63,4 @@ def show_remmina_accounts(debug=False):
     return res
     
 if __name__ == '__main__':
-    show_remmina_accounts()
+    show_remmina_accounts(bool(DEBUG))


### PR DESCRIPTION
On some OS (Ubuntu, Linux Mint) the `.pref` file and accounts files are saved on different directories. I have made the changes to allow configure via `env` variables 

On the other hand, the accounts files are not always numbers: `group_rdp_windows_server-127.0.0.1.remmina` is an example of an account file.

Finally, I have added the possibility to enable the debug mode via `env` variable.

It should fix the issue [#4](https://github.com/peppelinux/Remmina-password-exposer/issues/4)